### PR TITLE
Use admin_url() instead of home_url() to get the AJAX url

### DIFF
--- a/inc/VideoUploader/class.prso-adv-video-uploader.php
+++ b/inc/VideoUploader/class.prso-adv-video-uploader.php
@@ -222,7 +222,7 @@ class PrsoAdvVideoUploader {
 		$ch = curl_init();
 		
 		//Cache path to wp ajax script
-		$wp_ajax_url = home_url() . '/wp-admin/admin-ajax.php';
+		$wp_ajax_url = admin_url('admin-ajax.php');
 		
 		curl_setopt($ch, CURLOPT_URL, $wp_ajax_url);
 		curl_setopt($ch, CURLOPT_FRESH_CONNECT, true);


### PR DESCRIPTION
This PR changes the home_url() call to admin_url().

By using _home_url()_ to get an URL to wp-admin you assume too much of the directory structure of the site. For instance, we usually keep WordPress in a separate directory from our index.php, leading the wp-admin url to be _http://site.com/wordpress/wp-admin_ while home_url() returns _http://site.com/_.
